### PR TITLE
Update raycast

### DIFF
--- a/src/meshline/raycast.js
+++ b/src/meshline/raycast.js
@@ -14,8 +14,7 @@ export function MeshLineRaycast(raycaster, intersects) {
   if (raycaster.ray.intersectSphere(sphere, interRay) === false) {
     return
   }
-
-  inverseMatrix.getInverse(this.matrixWorld)
+  inverseMatrix.copy( this.matrixWorld ).invert();
   ray.copy(raycaster.ray).applyMatrix4(inverseMatrix)
 
   const vStart = new THREE.Vector3()


### PR DESCRIPTION
Invert method was deprecated, so I updated to the new way of inverting a matrix
![image](https://user-images.githubusercontent.com/12751670/154656020-ac19c7f4-bd18-4e35-b374-3308b6d7cc73.png)
